### PR TITLE
fix: add jungle planks

### DIFF
--- a/Vanilla_Resource_Pack/blocks.json
+++ b/Vanilla_Resource_Pack/blocks.json
@@ -1754,6 +1754,10 @@
     "sound": "wood",
     "textures": "jungle_sign"
   },
+  "jungle_planks": {
+    "sound": "wood",
+    "textures": "jungle_planks"
+  },
   "kelp": {
     "sound": "grass",
     "textures": {

--- a/Vanilla_Resource_Pack/blocks19-83.json
+++ b/Vanilla_Resource_Pack/blocks19-83.json
@@ -1694,6 +1694,10 @@
     "sound": "wood",
     "textures": "jungle_sign"
   },
+  "jungle_planks": {
+    "sound": "wood",
+    "textures": "jungle_planks"
+  },
   "kelp": {
     "sound": "grass",
     "textures": {

--- a/Vanilla_Resource_Pack/blocks20-0.json
+++ b/Vanilla_Resource_Pack/blocks20-0.json
@@ -2033,6 +2033,10 @@
       "sound" : "wood",
       "textures" : "jungle_sign"
    },
+   "jungle_planks": {
+      "sound": "wood",
+      "textures": "jungle_planks"
+   },
    "kelp" : {
       "sound" : "grass",
       "textures" : {

--- a/Vanilla_Resource_Pack/blocks_new.json
+++ b/Vanilla_Resource_Pack/blocks_new.json
@@ -1754,6 +1754,10 @@
       "sound" : "wood",
       "textures" : "jungle_sign"
    },
+   "jungle_planks": {
+      "sound": "wood",
+      "textures": "jungle_planks"
+   },
    "kelp" : {
       "sound" : "grass",
       "textures" : {

--- a/lookups/block_definition.json
+++ b/lookups/block_definition.json
@@ -879,6 +879,7 @@
 	"spruce_log":"tree",
 	"birch_log":"tree",
 	"jungle_log":"tree",
+    "jungle_planks": "cube",
 	"acacia_log":"tree",
 	"dark_oak_log":"tree",
 	"birch_fence":"fence",

--- a/lookups/material_list_names.json
+++ b/lookups/material_list_names.json
@@ -1095,6 +1095,9 @@
 	"minecraft:jungle_pressure_plate": {
 		"default": "Jungle PRessure Plate"
 	},
+	"minecraft:jungle_planks": {
+		"default": "Jungle Planks"
+	},
 	"minecraft:acacia_trapdoor": {
 		"default": "Acacia Trapdoor"
 	},


### PR DESCRIPTION
Jungle planks where missing from the tool.

Not sure if there is a sort order, but I couldn't detect it, so I just dropped it neer some `jungle` stuff.