### PR TITLE
Patch: Logger file writing for aws

### DIFF
--- a/armor_stand_geo_class.py
+++ b/armor_stand_geo_class.py
@@ -162,7 +162,7 @@ class armorstandgeo:
 
     def make_block(self, x, y, z, block_name, rot=None, top=False,data=0, trap_open=False, parent=None,variant="default", big = False):
         # make_block handles all the block processing, This function does need cleanup and probably should be broken into other helperfunctions for ledgiblity.
-        block_type = self.defs[block_name]
+        block_type = self.defs.get(block_name, "ignore")
         if block_type!="ignore":
             ghost_block_name = "block_{}_{}_{}".format(x, y, z)
             self.blocks[ghost_block_name] = {}

--- a/log_config.py
+++ b/log_config.py
@@ -34,9 +34,15 @@ def get_logger(
 
     # Place log in app root if we are frozen, otherwise use temp dir
     log_file = "structura.log"
-    if not hasattr(sys, "_MEIPASS"):
-        log_file =  os.path.join("tmp", log_file)
-    log_file_path = os.path.join(os.getcwd(), log_file)
+    # Frozen
+    if hasattr(sys, "_MEIPASS"):
+        log_file_path = os.path.join(os.getcwd(), log_file)
+    # Lambda env
+    elif "AWS_LAMBDA_FUNCTION_NAME" in os.environ:
+        log_file_path = os.path.join("tmp", log_file)
+    # IDE
+    else:
+        log_file_path = os.path.join(os.getcwd(), log_file)
 
     if log_level == "debug":
         file_formatter_str = (
@@ -61,7 +67,7 @@ def get_logger(
         # Log to file, attempt to add file handler for aws, discord
         if file_log:
             try:
-                os.makedirs(os.path.dirname(log_file_path), exist_ok=True)
+
                 file_handler = logging.FileHandler(
                     os.path.join(os.getcwd(), log_file_path)
                 )

--- a/log_config.py
+++ b/log_config.py
@@ -35,7 +35,7 @@ def get_logger(
     # Place log in app root if we are frozen, otherwise use temp dir
     log_file = "structura.log"
     if not hasattr(sys, "_MEIPASS"):
-        log_file =  os.path.join("temp", log_file)
+        log_file =  os.path.join("tmp", log_file)
     log_file_path = os.path.join(os.getcwd(), log_file)
 
     if log_level == "debug":

--- a/log_config.py
+++ b/log_config.py
@@ -1,5 +1,7 @@
 import logging
 import os
+import sys
+import traceback
 
 LOG_LEVELS = {
     "debug": logging.DEBUG,
@@ -9,7 +11,11 @@ LOG_LEVELS = {
     "critical": logging.CRITICAL
 }
 
-def get_logger(name="structura", log_file="structura.log", level=None):
+def get_logger(
+    level=None,
+    file_log=True,
+    console_log=True,
+):
     """
     Log configuration.
     """
@@ -23,27 +29,68 @@ def get_logger(name="structura", log_file="structura.log", level=None):
 
     level = LOG_LEVELS.get(log_level, logging.DEBUG)
 
-    logger = logging.getLogger(name)
+    logger = logging.getLogger(__name__)
     logger.setLevel(level)
+
+    # Place log in app root if we are frozen, otherwise use temp dir
+    log_file = "structura.log"
+    if not hasattr(sys, "_MEIPASS"):
+        log_file =  os.path.join("temp", log_file)
+    log_file_path = os.path.join(os.getcwd(), log_file)
+
+    if log_level == "debug":
+        file_formatter_str = (
+            "[%(asctime)s] [%(levelname)s - %(module)s:%(funcName)s] %(message)s"
+        )
+        console_formatter_str = "[%(levelname)s - %(module)s:%(funcName)s] %(message)s"
+    else:
+        file_formatter_str = "[%(asctime)s] [%(levelname)s - %(module)s] %(message)s"
+        console_formatter_str = "[%(levelname)s - %(module)s] %(message)s"
 
     # Avoid adding handlers multiple times
     if not logger.handlers:
-        # Log to file
-        file_handler = logging.FileHandler(os.path.join(os.getcwd(), log_file))
-        file_handler.setLevel(level)
-        file_formatter = logging.Formatter("[%(asctime)s] [%(levelname)s - %(name)s] %(message)s")
-        file_handler.setFormatter(file_formatter)
-        logger.addHandler(file_handler)
 
         # Log to console
-        console_handler = logging.StreamHandler()
-        console_handler.setLevel(level)
-        console_formatter = logging.Formatter("[%(levelname)s] %(message)s")
-        console_handler.setFormatter(console_formatter)
-        logger.addHandler(console_handler)
+        if console_log:
+            console_handler = logging.StreamHandler()
+            console_handler.setLevel(level)
+            console_formatter = logging.Formatter(console_formatter_str)
+            console_handler.setFormatter(console_formatter)
+            logger.addHandler(console_handler)
+
+        # Log to file, attempt to add file handler for aws, discord
+        if file_log:
+            try:
+                os.makedirs(os.path.dirname(log_file_path), exist_ok=True)
+                file_handler = logging.FileHandler(
+                    os.path.join(os.getcwd(), log_file_path)
+                )
+                file_handler.setLevel(level)
+                file_formatter = logging.Formatter(file_formatter_str)
+
+                file_handler.setFormatter(file_formatter)
+                logger.addHandler(file_handler)
+            except Exception:
+                logger.exception("Could not setup logging file handlder for file {} skipping.".format(log_file_path))
 
     else:
         for handler in logger.handlers:
             handler.setLevel(level)
+            formatter = None
+
+            # Dynamically remove handlers when called.
+            if isinstance(handler, logging.StreamHandler):
+                formatter = logging.Formatter(console_formatter_str)
+                if not console_log:
+                    logger.removeHandler(handler)
+                    handler.close()
+            elif isinstance(handler, logging.FileHandler):
+                formatter = logging.Formatter(file_formatter_str)
+                if not file_log:
+                    logger.removeHandler(handler)
+                    handler.close()
+
+            if formatter:
+                handler.setFormatter(formatter)
 
     return logger

--- a/structura.py
+++ b/structura.py
@@ -11,6 +11,7 @@ parser = argparse.ArgumentParser(description="Structura app that generates Resou
 
 parser.add_argument("--structure", type=str, help=".mcstructure file")
 parser.add_argument("--pack_name", type=str, help="Name of pack")
+parser.add_argument("--make_list", action='store_true',  help="Create Block list")
 parser.add_argument("--opacity", type=int, help="Opacity of blocks")
 parser.add_argument("--icon", type=str, help="Icon for pack")
 parser.add_argument("--offset", type=str, help="X, Y, X")
@@ -305,6 +306,9 @@ if args.structure and args.pack_name:
     structura_base.set_model_offset("", offset)
     structura_base.generate_with_nametags()
     structura_base.compile_pack()
+
+    if args.make_list:
+        structura_base.make_nametag_block_lists()
 
     log_build(structura_base)
 

--- a/structura_core.py
+++ b/structura_core.py
@@ -112,9 +112,26 @@ class structura:
             self.structure_files[model_name]["block_list"]=blocks
             ##consider temp folder
             self.armorstand_entity.export(self.pack_name)## this may be in the wrong spot, but transfered from 1.5
-        
+
+    def get_model_block_count(self, model_name: str) -> int:
+        """
+        Return the total number of blocks in the model.
+        :param model_name:
+        :return:
+        """
+        model =  self.structure_files.get(model_name)
+        if model is None:
+            return 0
+
+        count = 0
+        for k,v in model["block_list"].items():
+            count += v
+        return count
+
+
     def make_nametag_block_lists(self):
         ## consider temp file
+        logger.info("Generating Block list")
         file_names=[]
         for model_name in self.structure_files.keys():
             file_name="{}-{} block list.txt".format(self.pack_name,model_name)
@@ -122,9 +139,22 @@ class structura:
             all_blocks = self.structure_files[model_name]["block_list"]
             with open(file_name,"w+") as text_file:
                 text_file.write("This is a list of blocks, there is a known issue with variants, all blocks are reported as minecraft stores them\n")
+                # Decorate Colum names
+                column = f"{'Block':<25} {'Count':>4}  | {'Stacks':>5}   {'Remainder':>5} \n"
+                text_file.write("_"*len(column) + "\n")
+                text_file.write(column)
+                text_file.write("_" * len(column) + "\n")
+
                 for name in all_blocks.keys():
                     commonName = name.replace("minecraft:","")
-                    text_file.write("{}: {}\n".format(commonName,all_blocks[name]))
+                    count = all_blocks[name]
+                    stacks, blocks = self._make_block_count_text(count)
+                    text_file.write(f"{commonName:<25} {count:>4}  | {stacks:>5}  {blocks:>5}\n")
+
+                text_file.write("_" * len(column) + "\n")
+                block_count = self.get_model_block_count(model_name)
+                text_file.write(f"Block Count: {block_count}")
+
         return file_names
     def make_big_blocklist(self):
         ## consider temp file
@@ -220,6 +250,20 @@ class structura:
         logger.info(f"Pack Making Completed in {self.timers["total"]:.2} seconds")
         
         return f'{self.pack_name}.mcpack'
+
+    @staticmethod
+    def _make_block_count_text(count: int) -> tuple[int, int]:
+        """
+        Takes a block count and returns it as "Stacks, Remainder"
+        Helps make block counts more readable.
+        :param int count:
+        :return:
+        """
+
+        whole = count // 64
+        remainder = count % 64
+        return whole, remainder
+
     def _process_block(self,block):
         rot = None
         top = False

--- a/structura_core.py
+++ b/structura_core.py
@@ -154,29 +154,31 @@ class structura:
             file_names.append(file_name)
             all_blocks = self.structure_files[model_name]["block_list"]
             with open(file_name,"w+") as text_file:
-                text_file.write("This is a list of blocks, there is a known issue with variants, all blocks are reported as minecraft stores them\n")
-                # Decorate Colum names
-                column = f"{'Block':<25} {'Count':>4}  | {'Stacks':>5}   {'Remainder':>5} \n"
-                text_file.write("_"*len(column) + "\n")
-                text_file.write(column)
-                text_file.write("_" * len(column) + "\n")
-
                 # Sort block list alphabetically, sort items
                 # even if they are not str or don't have display names.
                 # Can occur when some blocks are unsupported.
                 sorted_blocks = sorted(all_blocks.keys(), key=lambda block: block.replace("minecraft:", "").lower())
+
+                text_file.write("This is a list of blocks, there is a known issue with variants, all blocks are reported as minecraft stores them\n")
+                # Decorate Colum names, also calculate max str length for colum width.
+                max_len = max(len("Block"), *(len(b) for b in sorted_blocks))
+                column = f"{'Block':<{max_len}} {'Count':>4}  | {'Stacks':>5}   {'Remainder':>5} \n"
+                text_file.write("_"*len(column) + "\n")
+                text_file.write(column)
+                text_file.write("_" * len(column) + "\n")
+
                 for name in sorted_blocks:
                     common_name = name.replace("minecraft:","")
                     count = all_blocks[name]
                     stacks, blocks = self._make_block_count_text(count)
-                    text_file.write(f"{common_name:<25} {count:>4}  | {stacks:>5}  {blocks:>5}\n")
+                    text_file.write(f"{common_name:<{max_len}} {count:>4}  | {stacks:>5}  {blocks:>5}\n")
 
                 text_file.write("_" * len(column) + "\n")
                 block_count = self.get_model_block_count(model_name)
-                text_file.write(f"Block Count: {block_count}")
+                text_file.write(f"Block Count: {block_count}\n")
 
-        text_file.write("_" * 10 + "\n")
-        text_file.write("Lookup version: {}\n".format(self.get_lookup_version()))
+                text_file.write("_" * 10 + "\n")
+                text_file.write("Lookup version: {}\n".format(self.get_lookup_version()))
 
         return file_names
     def make_big_blocklist(self):

--- a/structura_core.py
+++ b/structura_core.py
@@ -162,11 +162,15 @@ class structura:
                 text_file.write(column)
                 text_file.write("_" * len(column) + "\n")
 
-                for name in all_blocks.keys():
-                    commonName = name.replace("minecraft:","")
+                # Sort block list alphabetically, sort items
+                # even if they are not str or don't have display names.
+                # Can occur when some blocks are unsupported.
+                sorted_blocks = sorted(all_blocks.keys(), key=lambda block: block.replace("minecraft:", "").lower())
+                for name in sorted_blocks:
+                    common_name = name.replace("minecraft:","")
                     count = all_blocks[name]
                     stacks, blocks = self._make_block_count_text(count)
-                    text_file.write(f"{commonName:<25} {count:>4}  | {stacks:>5}  {blocks:>5}\n")
+                    text_file.write(f"{common_name:<25} {count:>4}  | {stacks:>5}  {blocks:>5}\n")
 
                 text_file.write("_" * len(column) + "\n")
                 block_count = self.get_model_block_count(model_name)

--- a/structura_core.py
+++ b/structura_core.py
@@ -130,6 +130,23 @@ class structura:
 
 
     def make_nametag_block_lists(self):
+        """
+        Creates a text files for each model with required
+        block counts organized block item.
+
+        example:
+            _______________________________________________________
+            Block                     Count | Stacks   Remainder
+            _______________________________________________________
+            Dirt                         1  |     0      1
+            Grass Block                324  |     5      4
+            ...
+            Stone Brick Slab             2  |     0      2
+            _______________________________________________________
+            Block Count: 3744
+
+        :return:
+        """
         ## consider temp file
         logger.info("Generating Block list")
         file_names=[]


### PR DESCRIPTION
Fix for the logger when creating `.log` file for a few use cases.

## From frozen/pyinstaller
`get_logger` looks for frozen attribute and creates the .log in the root dir for built and distributed version of the app.

## From bot/aws/IDE
- Attempts to add file handler into the `./temp/` making directory if needed.
- If this somehow fails file handler is just ignored for the duration of program.

#
- Minor tweaks to the block_list file formatting