### PR TITLE
Improve/fix start.sh

### DIFF
--- a/start.sh
+++ b/start.sh
@@ -3,7 +3,11 @@
 set -e
 cd "$(dirname "$0")"
 
-python3 -m venv .venv
-source .venv/bin/activate
-pip3 install -r requirements.txt
+if [ ! -d .venv ]; then
+	python3 -m venv .venv
+	source .venv/bin/activate
+	pip3 install -r requirements.txt
+else
+	source .venv/bin/activate
+fi
 python3 structura.py


### PR DESCRIPTION
- Sets executable bit for start.sh, so users don't have to run chmod +x
- Automatically creates python venv and installs everything in it
- set -e terminates the script if an error occurs on any of the lines (so no need for && after each command)
- Skip running `pip` if `.venv` already exists (meaning all libraries are likely installed) to improve startup time.

Simply doing `pip3 install -r requirments.txt` will fail on most distros with `error: externally-managed-environment`. It can be bypassed with `--break-system-packages` flag, but it's much better to install everything in the project and not clutter user's python libraries.

#!/bin/sh just specifies the interpreter for the script