### PR TITLE
Add quotes to example Structura cli command

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,7 +62,7 @@ chmod +x start.sh && sh start.sh
 
 To run from command line
 ```bash
-python structura.py --structure path\to\build.mcstructure --pack_name CLI Pack --overwrite True
+python structura.py --structure path\to\build.mcstructure --pack_name 'CLI Pack' --overwrite True
 ```
 
 ## Updating blocks


### PR DESCRIPTION
The current example has `--pack_name CLI Pack` which shell splits incorrectly. It causes the pack name to be 'CLI' and leaves Pack as a named argument.