### PR TITLE
fixed slab height issue

### DIFF
--- a/lookups/nbt_defs.json
+++ b/lookups/nbt_defs.json
@@ -26,7 +26,7 @@
 	"weirdo_direction":"rot",
 	"upside_down_bit":"top",
 	"top_slot_bit":"top",
-	"minecraft:vertical_half":"rot",
+	"minecraft:vertical_half":"top",
 	"open_bit":"open_bit",
 	"repeater_delay":"data",
 	"output_subtract_bit":"data",

--- a/structura_core.py
+++ b/structura_core.py
@@ -236,7 +236,11 @@ class structura:
                     rot = str(block["states"][key])
                 
             if nbt_def[key]== "top" and key in block["states"].keys():
-                top = bool(block["states"][key])
+                top_state = block["states"][key]
+                if key == "minecraft:vertical_half":
+                    top = str(top_state).lower() == "top"
+                else:
+                    top = bool(top_state)
             if nbt_def[key]== "open_bit" and "open_bit" in block["states"].keys():
                 open_bit = bool(block["states"][key])
             if nbt_def[key]== "data" and key in block["states"].keys():
@@ -283,4 +287,3 @@ class structura:
                 version_data = json.load(file)
                 return version_data["version"]
         return "No version found"
-

--- a/tests/test_slab_states.py
+++ b/tests/test_slab_states.py
@@ -1,0 +1,39 @@
+import unittest
+
+from nbtlib import Byte, String
+
+from structura_core import structura
+
+
+class SlabStateTests(unittest.TestCase):
+    def setUp(self):
+        self.processor = structura.__new__(structura)
+
+    def process(self, states):
+        block = {
+            "name": "minecraft:cut_copper_slab",
+            "states": states,
+        }
+        return self.processor._process_block(block)
+
+    def test_vertical_half_distinguishes_top_and_bottom_slabs(self):
+        top = self.process({"minecraft:vertical_half": String("top")})
+        bottom = self.process({"minecraft:vertical_half": String("bottom")})
+
+        self.assertIsNone(top[0])
+        self.assertTrue(top[1])
+        self.assertIsNone(bottom[0])
+        self.assertFalse(bottom[1])
+
+    def test_boolean_top_states_still_work(self):
+        for state_name in ("top_slot_bit", "upside_down_bit", "upper_block_bit"):
+            with self.subTest(state_name=state_name):
+                top = self.process({state_name: Byte(1)})
+                bottom = self.process({state_name: Byte(0)})
+
+                self.assertTrue(top[1])
+                self.assertFalse(bottom[1])
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
### Summary

Fixes #273: slabs now keep their original height.

### Results

Tested and verifed the fix by building and running a standalone exe and using it to make .mcpacks from the `test_structures` folder.

During testing I found there are minor alignment issues with some wooden slabs but not others like smooth stone slabs. (see images). 

<img width="676" height="284" alt="Screenshot 2026-08-03 114819" src="https://github.com/user-attachments/assets/509b347a-a6ee-446e-ac91-eb792a9b19f5" />
<img width="676" height="334" alt="Screenshot 2026-08-03 114830" src="https://github.com/user-attachments/assets/2ea58413-f8e1-4b09-a96d-86acddc1fe2b" />
<img width="676" height="369" alt="Screenshot 2026-08-03 122935" src="https://github.com/user-attachments/assets/a484bf9b-5ce4-4281-99f5-a3e27e251a8c" />